### PR TITLE
OCTV: make BrikInfo Octave-compatible by not using "setstr" but "char"

### DIFF
--- a/src/matlab/BrikInfo_SectionValue.m
+++ b/src/matlab/BrikInfo_SectionValue.m
@@ -78,7 +78,7 @@ err = 1;
 		
 	%read all values
 		Svals = BRIKinfo(itmp:inxt); %that's where the values are
-		inl = find(setstr(Svals) == 10 | setstr(Svals) == 13); %find any new lines left in Svals (13 was added to work in DOS (CR and LF))
+		inl = find(char(Svals) == 10 | char(Svals) == 13); %find any new lines left in Svals (13 was added to work in DOS (CR and LF))
 		
 		if (~isempty(inl)), 
 			Svals(inl) = ' '; %replace them by space characters

--- a/src/matlab/GetNextLine.m
+++ b/src/matlab/GetNextLine.m
@@ -41,7 +41,7 @@ DBG = 1;
 err = 1;
 strt = 0; stp = 0;
 
-inl = find(setstr(s) == 10);
+inl = find(char(s) == 10);
 
 Nlines = length(inl);
 if (n <= Nlines),


### PR DESCRIPTION
This minor change makes BrikInfo more compatible with GNU Octave.